### PR TITLE
Skip loading files if the directory does not exist

### DIFF
--- a/src/acm_agents.py
+++ b/src/acm_agents.py
@@ -179,7 +179,14 @@ loader = DirectoryLoader(
     path="load_files",
 )
 
-yamlFiles = loader.load()
+try:
+    yamlFiles = loader.load()
+except FileNotFoundError as e:
+    print(f"[Info] No files found in directory: '{loader.path}'. Skipping load.")
+    yamlFiles = []
+except Exception as e:
+    print(f"An unexpected error occurred while loading files from '{loader.path}': {e}. No files were loaded.")
+    yamlFiles = []
 
 def router_node(state: AgentState):
     """


### PR DESCRIPTION
🛠️ Summary
This PR adds error handling for cases where the specified file directory does not exist. Instead of raising an exception, the application now gracefully skips the load step and logs a clear message.

✅ Changes
Added FileNotFoundError handling around DirectoryLoader.load()

Added informative log messages for missing or empty directories

Prevented app failure when load_files directory is not present

